### PR TITLE
Update badges and logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--header-start-->
-<img src=".github/nhm-logo.svg" align="left" width="150px" height="100px" hspace="40"/>
+<img src="https://github.com/NaturalHistoryMuseum/ckanext-attribution/blob/main/.github/nhm-logo.svg" align="left" width="150px" height="100px" hspace="40"/>
 
 # ckanext-attribution
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # ckanext-attribution
 
-[![Tests](https://img.shields.io/github/workflow/status/NaturalHistoryMuseum/ckanext-attribution/Tests?style=flat-square)](https://github.com/NaturalHistoryMuseum/ckanext-attribution/actions/workflows/main.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/NaturalHistoryMuseum/ckanext-attribution/main.yml?style=flat-square)](https://github.com/NaturalHistoryMuseum/ckanext-attribution/actions/workflows/main.yml)
 [![Coveralls](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/ckanext-attribution/main?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/ckanext-attribution)
 [![CKAN](https://img.shields.io/badge/ckan-2.9.7-orange.svg?style=flat-square)](https://github.com/ckan/ckan)
 [![Python](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-blue.svg?style=flat-square)](https://www.python.org/)


### PR DESCRIPTION
Fix github actions badge (see https://github.com/badges/shields/issues/8671) and use a full https link for the logo so that it works on PyPI as well.